### PR TITLE
Add paddle distribution

### DIFF
--- a/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
+++ b/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
@@ -40,11 +40,6 @@ namespace osu.Game.Rulesets.Tau.Tests
         {
             Children = new Drawable[]
             {
-                new Box
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Colour = Color4Extensions.FromHex("#333")
-                },
                 new PaddleDistributionGraph(events, new TestBeatmap(new TauRuleset().RulesetInfo))
                 {
                     Anchor = Anchor.Centre,

--- a/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
+++ b/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
@@ -1,13 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Tau.Objects;
+using osu.Game.Rulesets.Tau.Statistics;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Visual;
 using osuTK;

--- a/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
+++ b/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Rulesets.Tau.Tests
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Size = new Vector2(600, 250)
+                    Size = new Vector2(600, 350)
                 }
             };
         });

--- a/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
+++ b/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Utils;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Tau.Objects;
+using osu.Game.Tests.Beatmaps;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Tau.Tests
+{
+    public class TestScenePaddleDistribution : OsuTestScene
+    {
+        [Test]
+        public void TestManyDistributionEvents()
+        {
+            createTest(CreateDistributedHitEvents());
+        }
+
+        [Test]
+        public void TestAroundCentre()
+        {
+            var beatmap = new TestBeatmap(new TauRuleset().RulesetInfo);
+            var angleRange = (float)BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.BaseDifficulty.CircleSize, 75, 25, 10);
+            createTest(Enumerable.Range(0, (int)angleRange).Select(i => new HitEvent(i / 50f, HitResult.Perfect, new Beat(), new Beat(), new Vector2((i - (angleRange / 2)), 0))).ToList());
+        }
+
+        [Test]
+        public void TestNoEvents()
+        {
+            createTest(new List<HitEvent>());
+        }
+
+        private void createTest(List<HitEvent> events) => AddStep("create test", () =>
+        {
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4Extensions.FromHex("#333")
+                },
+                new PaddleDistributionGraph(events, new TestBeatmap(new TauRuleset().RulesetInfo))
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(600, 250)
+                }
+            };
+        });
+
+        public static List<HitEvent> CreateDistributedHitEvents()
+        {
+            var hitEvents = new List<HitEvent>();
+            var beatmap = new TestBeatmap(new TauRuleset().RulesetInfo);
+            var angleRange = (float)BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.BaseDifficulty.CircleSize, 75, 25, 10);
+
+            for (int i = 0; i < 100; i++)
+            {
+                hitEvents.Add(new HitEvent(i - 25, HitResult.Perfect, new Beat(), new Beat(), new Vector2(RNG.NextSingle(-(angleRange / 2), angleRange / 2), 0)));
+            }
+
+            return hitEvents;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
+++ b/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
@@ -11,6 +11,7 @@ using osu.Game.Rulesets.Tau.Objects;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Visual;
 using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Tau.Tests
 {
@@ -40,6 +41,15 @@ namespace osu.Game.Rulesets.Tau.Tests
         {
             Children = new Drawable[]
             {
+                new Box
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.X,
+                    Height = 250,
+                    Colour = Color4.Red,
+                    Alpha = 0.25f
+                },
                 new PaddleDistributionGraph(events, new TestBeatmap(new TauRuleset().RulesetInfo))
                 {
                     Anchor = Anchor.Centre,

--- a/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
+++ b/osu.Game.Rulesets.Tau.Tests/TestScenePaddleDistribution.cs
@@ -44,7 +44,8 @@ namespace osu.Game.Rulesets.Tau.Tests
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Size = new Vector2(600, 350)
+                    RelativeSizeAxes = Axes.X,
+                    Height = 250,
                 }
             };
         });

--- a/osu.Game.Rulesets.Tau/Extensions.cs
+++ b/osu.Game.Rulesets.Tau/Extensions.cs
@@ -19,21 +19,9 @@ namespace osu.Game.Rulesets.Tau
 
         public static float GetDeltaAngle(float a, float b)
         {
-            float x = b;
-            float y = a;
+            var res = a - b;
 
-            if (a > b)
-            {
-                x = a;
-                y = b;
-            }
-
-            if (x - y < 180)
-                x -= y;
-            else
-                x = 360 - x + y;
-
-            return x;
+            return (res + 180) % 360 - 180;
         }
 
         public static float GetHitObjectAngle(this Vector2 target)

--- a/osu.Game.Rulesets.Tau/Judgements/TauJudgementResult.cs
+++ b/osu.Game.Rulesets.Tau/Judgements/TauJudgementResult.cs
@@ -1,0 +1,18 @@
+﻿using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Tau.Objects;
+
+namespace osu.Game.Rulesets.Tau.Judgements
+{
+    public class TauJudgementResult : JudgementResult
+    {
+        public TauHitObject TauHitObject => (TauHitObject)HitObject;
+
+        public float? DeltaAngle;
+
+        public TauJudgementResult(HitObject hitObject, Judgement judgement)
+            : base(hitObject, judgement)
+        {
+        }
+    }
+}

--- a/osu.Game.Rulesets.Tau/Mods/TauModRelax.cs
+++ b/osu.Game.Rulesets.Tau/Mods/TauModRelax.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Rulesets.Tau.Mods
 
                         var play = (TauPlayfield)playfield;
 
-                        if (tauHit.HitObject.HitWindows.CanBeHit(relativetime) && play.CheckIfWeCanValidate(tauHit.HitObject.Angle))
+                        if (tauHit.HitObject.HitWindows.CanBeHit(relativetime) && play.CheckIfWeCanValidate(tauHit.HitObject.Angle).Item1)
                             requiresHit = true;
 
                         break;

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
@@ -9,6 +9,7 @@ using osu.Game.Graphics;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Tau.Configuration;
+using osu.Game.Rulesets.Tau.Judgements;
 using osu.Game.Rulesets.Tau.Skinning.Default;
 using osu.Game.Skinning;
 using osuTK;
@@ -123,7 +124,17 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
                 if (!validActionPressed)
                     ApplyResult(r => r.Type = HitResult.Miss);
                 else
-                    ApplyResult(r => r.Type = result);
+                    ApplyResult(r =>
+                    {
+                        var beatResult = (TauJudgementResult)r;
+
+                        if (result.IsHit())
+                        {
+                            beatResult.DeltaAngle = validation.Item2;
+                        }
+
+                        beatResult.Type = result;
+                    });
             }
         }
 

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableBeat.cs
@@ -111,7 +111,9 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
                 return;
             }
 
-            if (CheckValidation.Invoke(HitObject.Angle))
+            var validation = CheckValidation.Invoke(HitObject.Angle);
+
+            if (validation.Item1)
             {
                 var result = HitObject.HitWindows.ResultFor(timeOffset);
 

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableSlider.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableSlider.cs
@@ -338,7 +338,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
             }
         }
 
-        public bool IsWithinPaddle => CheckValidation?.Invoke(Vector2.Zero.GetDegreesFromPosition(path.Position)) ?? false;
+        public bool IsWithinPaddle => CheckValidation?.Invoke(Vector2.Zero.GetDegreesFromPosition(path.Position)).Item1 ?? false;
 
         private TauInputManager tauActionInputManager;
         internal TauInputManager TauActionInputManager => tauActionInputManager ??= GetContainingInputManager() as TauInputManager;

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
@@ -1,5 +1,7 @@
 using System;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Tau.Judgements;
 
 namespace osu.Game.Rulesets.Tau.Objects.Drawables
 {
@@ -29,6 +31,8 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
         protected override double InitialLifetimeOffset => HitObject.TimePreempt;
 
         public Func<DrawableHitObject, double, bool> CheckHittable;
+
+        protected override JudgementResult CreateResult(Judgement judgement) => new TauJudgementResult(HitObject, judgement);
 
         public void MissForcefully() => ApplyResult(r => r.Type = r.Judgement.MinResult);
     }

--- a/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
+++ b/osu.Game.Rulesets.Tau/Objects/Drawables/DrawableTauHitObject.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Rulesets.Tau.Objects.Drawables
         {
         }
 
-        public Func<float, bool> CheckValidation;
+        public Func<float, (bool, float)> CheckValidation;
 
         /// <summary>
         /// A list of keys which can result in hits for this HitObject.

--- a/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
+++ b/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Tau.Objects;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Rulesets.Tau
+{
+    public class PaddleDistributionGraph : CompositeDrawable
+    {
+        private readonly IReadOnlyList<HitEvent> hitEvents;
+
+        private const float scale = 2f;
+        private const float bin_per_angle = 0.5f;
+        private float radius => (Math.Max(DrawHeight, DrawWidth)) * scale;
+        private float angleRange;
+        private Container barsContainer;
+
+        public PaddleDistributionGraph(IReadOnlyList<HitEvent> hitEvents, IBeatmap beatmap)
+        {
+            this.hitEvents = hitEvents.Where(e => !(e.HitObject.HitWindows is HitWindows.EmptyHitWindows) && e.HitObject is Beat && e.Result.IsHit()).ToList();
+
+            angleRange = (float)BeatmapDifficulty.DifficultyRange(beatmap.BeatmapInfo.BaseDifficulty.CircleSize, 75, 25, 10);
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            if (hitEvents == null || hitEvents.Count == 0)
+                return;
+
+            int totalDistributionBins = (int)(angleRange / bin_per_angle) + 1;
+
+            int[] bins = new int[totalDistributionBins];
+
+            foreach (var hit in hitEvents)
+            {
+                var angle = hit.Position?.X ?? 0;
+                angle += angleRange / 2;
+
+                var index = MathF.Round((int)(angle / bin_per_angle), MidpointRounding.AwayFromZero);
+
+                bins[(int)index]++;
+            }
+
+            int maxCount = bins.Max();
+            var bars = new Bar[totalDistributionBins];
+
+            for (int i = 0; i < bars.Length; i++)
+                bars[i] = new Bar
+                {
+                    Height = Math.Max(0.05f, (float)bins[i] / maxCount),
+                    Index = i
+                };
+
+            var paddedAngleRange = angleRange + (1 * 2); // 3° padding horizontally
+
+            InternalChildren = new Drawable[]
+            {
+                barsContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                },
+                new CircularContainer
+                {
+                    Masking = true,
+                    BorderColour = Colour4.White,
+                    BorderThickness = 2,
+                    RelativeSizeAxes = Axes.Both,
+                    FillAspectRatio = 1,
+                    FillMode = FillMode.Fill,
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Scale = new Vector2(scale),
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.White.Opacity(0.25f)
+                        },
+                        new CircularProgress
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Current = new BindableDouble(paddedAngleRange / 360),
+                            InnerRadius = 0.05f,
+                            Rotation = -paddedAngleRange / 2,
+                        }
+                    }
+                }
+            };
+
+            var barRadius = radius - (17 * scale);
+
+            foreach (var bar in bars)
+            {
+                var pos = Extensions.GetCircularPosition(barRadius, (bar.Index * bin_per_angle) - (angleRange / 2));
+                pos.Y += radius;
+
+                barsContainer.Add(bar.With(b =>
+                {
+                    b.Position = pos;
+                    b.Height /= 2;
+                }));
+            }
+        }
+
+        private class Bar : CompositeDrawable
+        {
+            public float Index { get; set; }
+
+            public Bar()
+            {
+                Anchor = Anchor.TopCentre;
+                Origin = Anchor.TopCentre;
+
+                RelativeSizeAxes = Axes.Y;
+                Width = 5;
+
+                Padding = new MarginPadding { Horizontal = 1 };
+
+                InternalChild = new Circle
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4Extensions.FromHex("#66FFCC")
+                };
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
+++ b/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
@@ -146,6 +146,9 @@ namespace osu.Game.Rulesets.Tau
                     }
                 }
             };
+
+            radius = (Height * 4) / 2;
+            barsContainer.AddRange(calculateBars());
         }
 
         protected override void Update()
@@ -157,20 +160,12 @@ namespace osu.Game.Rulesets.Tau
 
             if (!layout.IsValid)
             {
-                barsContainer.Clear();
-                radius = (Height * 4) / 2;
-                var bars = calculateBars();
-
-                foreach (var bar in bars)
+                foreach (Bar bar in barsContainer)
                 {
                     var pos = Extensions.GetCircularPosition(radius - 17, (bar.Index * bin_per_angle) - (angleRange / 2));
                     pos.Y += radius;
 
-                    barsContainer.Add(bar.With(b =>
-                    {
-                        b.Position = pos;
-                        b.Height *= 0.3f;
-                    }));
+                    bar.Position = pos;
                 }
 
                 layout.Validate();
@@ -199,7 +194,7 @@ namespace osu.Game.Rulesets.Tau
             for (int i = 0; i < bars.Length; i++)
                 bars[i] = new Bar
                 {
-                    Height = Math.Max(0.075f, (float)bins[i] / maxCount),
+                    Height = Math.Max(0.075f, (float)bins[i] / maxCount) * 0.3f,
                     Index = i
                 };
 

--- a/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
+++ b/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Rulesets.Tau
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
                             Height = 0.26f,
-                            Colour = ColourInfo.GradientVertical(Color4.White, Color4.Transparent),
+                            Colour = ColourInfo.GradientVertical(Color4.White, Color4.White.Opacity(-0.2f)),
                         }
                     }
                 },
@@ -146,7 +146,7 @@ namespace osu.Game.Rulesets.Tau
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
                             RelativeSizeAxes = Axes.Both,
-                            Colour = Color4.DarkGray.Darken(0.5f).Opacity(0.2f),
+                            Colour = ColourInfo.GradientVertical(Color4.DarkGray.Darken(0.5f).Opacity(0.3f), Color4.DarkGray.Darken(0.5f).Opacity(0f)),
                             Height = 0.25f,
                         },
                         new CircularProgress

--- a/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
+++ b/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
@@ -172,14 +172,11 @@ namespace osu.Game.Rulesets.Tau
                 {
                     Height = Math.Max(0.075f, (float)bins[i] / maxCount) * 0.3f,
                     Position = Extensions.GetCircularPosition(radius - 17, (i * bin_per_angle) - (angleRange / 2)) + new Vector2(0, radius),
-                    Index = i
                 });
         }
 
         private class Bar : CompositeDrawable
         {
-            public float Index { get; set; }
-
             public Bar()
             {
                 Anchor = Anchor.TopCentre;

--- a/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
+++ b/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
@@ -5,7 +5,9 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Game.Beatmaps;
@@ -73,12 +75,65 @@ namespace osu.Game.Rulesets.Tau
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
                 },
+                new BufferedContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    FillAspectRatio = 1,
+                    FillMode = FillMode.Fill,
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Scale = new Vector2(scale),
+                    Children = new Drawable[]
+                    {
+                        new Container
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            RelativeSizeAxes = Axes.Both,
+                            Masking = true,
+                            Height = 0.25f,
+                            Child = new CircularContainer
+                            {
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                                RelativeSizeAxes = Axes.Both,
+                                Masking = true,
+                                BorderThickness = 2,
+                                BorderColour = Color4.White,
+                                Height = 4,
+                                Child = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Alpha = 0,
+                                    AlwaysPresent = true,
+                                }
+                            },
+                        },
+                        new Box
+                        {
+                            Blending = new BlendingParameters
+                            {
+                                // Don't change the destination colour.
+                                RGBEquation = BlendingEquation.Add,
+                                Source = BlendingType.Zero,
+                                Destination = BlendingType.One,
+                                // Subtract the cover's alpha from the destination (points with alpha 1 should make the destination completely transparent).
+                                AlphaEquation = BlendingEquation.Add,
+                                SourceAlpha = BlendingType.Zero,
+                                DestinationAlpha = BlendingType.SrcAlpha,
+                            },
+                            RelativeSizeAxes = Axes.Both,
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Height = 0.26f,
+                            Colour = ColourInfo.GradientVertical(Color4.White, Color4.Transparent),
+                        }
+                    }
+                },
                 new CircularContainer
                 {
-                    Masking = true,
-                    BorderColour = Colour4.White,
-                    BorderThickness = 2,
                     RelativeSizeAxes = Axes.Both,
+                    Masking = true,
                     FillAspectRatio = 1,
                     FillMode = FillMode.Fill,
                     Anchor = Anchor.TopCentre,
@@ -88,8 +143,11 @@ namespace osu.Game.Rulesets.Tau
                     {
                         new Box
                         {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
                             RelativeSizeAxes = Axes.Both,
-                            Colour = Color4.White.Opacity(0.25f)
+                            Colour = Color4.DarkGray.Darken(0.5f).Opacity(0.2f),
+                            Height = 0.25f,
                         },
                         new CircularProgress
                         {

--- a/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
+++ b/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
@@ -13,6 +13,7 @@ using osu.Framework.Layout;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Tau.Objects;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Game.Rulesets.Tau
@@ -42,7 +43,9 @@ namespace osu.Game.Rulesets.Tau
             if (hitEvents == null || hitEvents.Count == 0)
                 return;
 
-            var paddedAngleRange = angleRange + (1 * 2); // 3° padding horizontally
+            var paddedAngleRange = angleRange + (1 * 2); // 2° padding horizontally
+
+            FillMode = FillMode.Fit;
 
             InternalChildren = new Drawable[]
             {
@@ -50,8 +53,10 @@ namespace osu.Game.Rulesets.Tau
                 {
                     RelativeSizeAxes = Axes.Both,
                     RelativePositionAxes = Axes.Y,
-                    Y = 0.1f,
-                    FillMode = FillMode.Fill,
+                    Y = 0.06f,
+                    Scale = new Vector2(1),
+                    FillAspectRatio = 1,
+                    FillMode = FillMode.Fit,
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
                 },
@@ -59,7 +64,8 @@ namespace osu.Game.Rulesets.Tau
                 {
                     RelativeSizeAxes = Axes.Both,
                     FillAspectRatio = 1,
-                    FillMode = FillMode.Fill,
+                    FillMode = FillMode.Fit,
+                    Scale = new Vector2(4),
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
                     Children = new Drawable[]
@@ -77,7 +83,7 @@ namespace osu.Game.Rulesets.Tau
                                 Origin = Anchor.TopCentre,
                                 RelativeSizeAxes = Axes.Both,
                                 Masking = true,
-                                BorderThickness = 4,
+                                BorderThickness = 2,
                                 BorderColour = Color4.White,
                                 Height = 4,
                                 Child = new Box
@@ -114,7 +120,8 @@ namespace osu.Game.Rulesets.Tau
                     RelativeSizeAxes = Axes.Both,
                     Masking = true,
                     FillAspectRatio = 1,
-                    FillMode = FillMode.Fill,
+                    FillMode = FillMode.Fit,
+                    Scale = new Vector2(4),
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
                     Children = new Drawable[]
@@ -151,7 +158,7 @@ namespace osu.Game.Rulesets.Tau
             if (!layout.IsValid)
             {
                 barsContainer.Clear();
-                radius = DrawWidth / 2;
+                radius = (Height * 4) / 2;
                 var bars = calculateBars();
 
                 foreach (var bar in bars)
@@ -162,7 +169,7 @@ namespace osu.Game.Rulesets.Tau
                     barsContainer.Add(bar.With(b =>
                     {
                         b.Position = pos;
-                        b.Height *= 0.15f;
+                        b.Height *= 0.3f;
                     }));
                 }
 
@@ -192,7 +199,7 @@ namespace osu.Game.Rulesets.Tau
             for (int i = 0; i < bars.Length; i++)
                 bars[i] = new Bar
                 {
-                    Height = Math.Max(0.05f, (float)bins[i] / maxCount),
+                    Height = Math.Max(0.075f, (float)bins[i] / maxCount),
                     Index = i
                 };
 

--- a/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
+++ b/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Tau
         private readonly IReadOnlyList<HitEvent> hitEvents;
 
         private const float bin_per_angle = 1f;
-        private float radius => DrawWidth / 2;
+        private float radius;
         private float angleRange;
         private Container barsContainer;
         private readonly LayoutValue layout = new LayoutValue(Invalidation.DrawSize);
@@ -49,6 +49,8 @@ namespace osu.Game.Rulesets.Tau
                 barsContainer = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
+                    RelativePositionAxes = Axes.Y,
+                    Y = 0.1f,
                     FillMode = FillMode.Fill,
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre,
@@ -149,11 +151,12 @@ namespace osu.Game.Rulesets.Tau
             if (!layout.IsValid)
             {
                 barsContainer.Clear();
+                radius = DrawWidth / 2;
                 var bars = calculateBars();
 
                 foreach (var bar in bars)
                 {
-                    var pos = Extensions.GetCircularPosition(radius - 13, (bar.Index * bin_per_angle) - (angleRange / 2));
+                    var pos = Extensions.GetCircularPosition(radius - 17, (bar.Index * bin_per_angle) - (angleRange / 2));
                     pos.Y += radius;
 
                     barsContainer.Add(bar.With(b =>
@@ -207,8 +210,6 @@ namespace osu.Game.Rulesets.Tau
 
                 RelativeSizeAxes = Axes.Y;
                 Width = 5;
-
-                Padding = new MarginPadding { Horizontal = 1 };
 
                 InternalChild = new Circle
                 {

--- a/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
+++ b/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Tau.Objects;
+using osu.Game.Screens.Ranking.Expanded.Accuracy;
 using osuTK;
 using osuTK.Graphics;
 
@@ -129,14 +130,16 @@ namespace osu.Game.Rulesets.Tau
                             Colour = ColourInfo.GradientVertical(Color4.DarkGray.Darken(0.5f).Opacity(0.3f), Color4.DarkGray.Darken(0.5f).Opacity(0f)),
                             Height = 0.25f,
                         },
-                        new CircularProgress
+                        new SmoothCircularProgress
                         {
                             RelativeSizeAxes = Axes.Both,
+                            RelativePositionAxes = Axes.Both,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Current = new BindableDouble(paddedAngleRange / 360),
                             InnerRadius = 0.05f,
                             Rotation = -paddedAngleRange / 2,
+                            Y = 0.0035f
                         }
                     }
                 }

--- a/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
+++ b/osu.Game.Rulesets.Tau/PaddleDistributionGraph.cs
@@ -153,7 +153,7 @@ namespace osu.Game.Rulesets.Tau
 
                 foreach (var bar in bars)
                 {
-                    var pos = Extensions.GetCircularPosition(radius - 30, (bar.Index * bin_per_angle) - (angleRange / 2));
+                    var pos = Extensions.GetCircularPosition(radius - 13, (bar.Index * bin_per_angle) - (angleRange / 2));
                     pos.Y += radius;
 
                     barsContainer.Add(bar.With(b =>

--- a/osu.Game.Rulesets.Tau/Scoring/TauScoreProcessor.cs
+++ b/osu.Game.Rulesets.Tau/Scoring/TauScoreProcessor.cs
@@ -1,8 +1,16 @@
-﻿using osu.Game.Rulesets.Scoring;
+﻿using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Tau.Judgements;
+using osuTK;
 
 namespace osu.Game.Rulesets.Tau.Scoring
 {
     public class TauScoreProcessor : ScoreProcessor
     {
+        protected override HitEvent CreateHitEvent(JudgementResult result)
+            => base.CreateHitEvent(result).With(new Vector2((result as TauJudgementResult)?.DeltaAngle ?? 0, 0)); // Just use the X value as the delta value.
+
+        protected override JudgementResult CreateResult(HitObject hitObject, Judgement judgement) => new TauJudgementResult(hitObject, judgement);
     }
 }

--- a/osu.Game.Rulesets.Tau/Statistics/PaddleDistributionGraph.cs
+++ b/osu.Game.Rulesets.Tau/Statistics/PaddleDistributionGraph.cs
@@ -8,7 +8,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.UserInterface;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Tau.Objects;
@@ -16,7 +15,7 @@ using osu.Game.Screens.Ranking.Expanded.Accuracy;
 using osuTK;
 using osuTK.Graphics;
 
-namespace osu.Game.Rulesets.Tau
+namespace osu.Game.Rulesets.Tau.Statistics
 {
     public class PaddleDistributionGraph : CompositeDrawable
     {

--- a/osu.Game.Rulesets.Tau/TauRuleset.cs
+++ b/osu.Game.Rulesets.Tau/TauRuleset.cs
@@ -132,6 +132,17 @@ namespace osu.Game.Rulesets.Tau
             {
                 Columns = new[]
                 {
+                    new StatisticItem("Paddle Distribution", new PaddleDistributionGraph(score.HitEvents, playableBeatmap)
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = 250,
+                    })
+                }
+            },
+            new StatisticRow
+            {
+                Columns = new[]
+                {
                     new StatisticItem(string.Empty, new SimpleStatisticTable(3, new SimpleStatisticItem[]
                     {
                         new UnstableRate(score.HitEvents)

--- a/osu.Game.Rulesets.Tau/TauRuleset.cs
+++ b/osu.Game.Rulesets.Tau/TauRuleset.cs
@@ -24,6 +24,7 @@ using osu.Game.Rulesets.Tau.Mods;
 using osu.Game.Rulesets.Tau.Replays;
 using osu.Game.Rulesets.Tau.Scoring;
 using osu.Game.Rulesets.Tau.Skinning.Legacy;
+using osu.Game.Rulesets.Tau.Statistics;
 using osu.Game.Rulesets.Tau.UI;
 using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;

--- a/osu.Game.Rulesets.Tau/UI/Cursor/TauCursor.cs
+++ b/osu.Game.Rulesets.Tau/UI/Cursor/TauCursor.cs
@@ -43,11 +43,11 @@ namespace osu.Game.Rulesets.Tau.UI.Cursor
             this.beatmap.BindTo(beatmap);
         }
 
-        public bool CheckForValidation(float angle)
+        public (bool, float) CheckForValidation(float angle)
         {
             var angleDiff = Extensions.GetDeltaAngle(PaddleDrawable.Rotation, angle);
 
-            return Math.Abs(angleDiff) <= angleRange / 2;
+            return (Math.Abs(angleDiff) <= angleRange / 2, angleDiff);
         }
 
         protected override bool OnMouseMove(MouseMoveEvent e)

--- a/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
+++ b/osu.Game.Rulesets.Tau/UI/TauPlayfield.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Rulesets.Tau.UI
 
         protected override HitObjectLifetimeEntry CreateLifetimeEntry(HitObject hitObject) => new TauHitObjectLifetimeEntry(hitObject);
 
-        public bool CheckIfWeCanValidate(float angle) => cursor.CheckForValidation(angle);
+        public (bool, float) CheckIfWeCanValidate(float angle) => cursor.CheckForValidation(angle);
 
         [Resolved]
         private OsuColour colour { get; set; }


### PR DESCRIPTION
Opening this up to allow @LumpBloom7 to create the faded circle background effect as seen in this design:
![](https://trello-attachments.s3.amazonaws.com/607d1346701fb66db7b3b121/6109eec1b59ccc88c8ee6118/607ebedfd16b13d7c8c143c3490af8a8/713hZCVXp3.png)

Known issues:
- ~Bars doesn't scale properly alongside the container.~
- ~Padding is too big on paddle (probably due to above?)~